### PR TITLE
use devicons as font-family <i>

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -358,14 +358,17 @@
       transparent 80%
     );
   }
-
+  
   /* Icon zoom effect - super simple */
   .tech-skill-card img,
+  .tech-skill-card i,
   .tech-skill-card .fas {
     transition: transform var(--hover-transition);
+    font-size: 56px;
   }
 
   .tech-skill-card:hover img,
+  .tech-skill-card:hover i,
   .tech-skill-card:hover .fas {
     transform: scale(var(--hover-scale));
   }

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,6 +17,7 @@
     {{ if eq hugo.Environment "production" }}
       {{ $styles = $styles | minify | fingerprint }}
     {{ end }}
+    <link rel="stylesheet" type='text/css' href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css" />    
     <link rel="stylesheet" href="{{ $styles.RelPermalink }}?v={{ now.Unix }}" data-version="{{ now.Unix }}">
     <style>
         /* Critical CSS to prevent FOUC */

--- a/layouts/partials/technical.html
+++ b/layouts/partials/technical.html
@@ -25,11 +25,7 @@
                 {{ if .devicon_name }}
                   <!-- Use explicit devicon_name if provided -->
                   <div class="h-14 flex items-center justify-center mb-2">
-                    <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/{{ .devicon_name }}/{{ .devicon_name }}-original.svg" 
-                         alt="{{ .name }}" 
-                         width="56" 
-                         height="56" 
-                         data-animation="skill-icon" />
+                    <i class="devicon devicon-{{ .devicon_name }}-plain colored" data-animation="skill-icon"></i>
                   </div>
                 {{ else }}
                   <!-- Fallback to FontAwesome with random colors -->


### PR DESCRIPTION
Hi @felipecordero,

I changed the implementation of devicon to a cleaner icon tag from custom font-family, loaded from cdn.
This should optimize browser requests while rendering page, cause it doesn't request a single image for every icon.

It also solve a little name mismatch on graphql icon which seems to me the only one with with "-plain" suffix...
https://github.com/setola/emanueletessore.com/commit/b898872bdb0a2d8cc2c85ec234c2d2315ee8c292#diff-e066b057255e3907be2d0485eca69e768ed17d505025f48f6401f1dfd03b6857L124

here's a demo: https://www.emanueletessore.com/#technical

Feel free to close this PR if you prefer the current implementation.

Cheers :)